### PR TITLE
Switch POST and PUT in the first paragraph

### DIFF
--- a/_posts/2012-12-12-put-vs-post.html
+++ b/_posts/2012-12-12-put-vs-post.html
@@ -9,8 +9,8 @@ author_email: jthijssen@noxlogic.nl
 <p class="question">When should we use PUT and when should we use POST?</p>
 
 <p>The HTTP methods [POST] and [PUT] aren't the HTTP equivalent of the CRUD's create and update. They both serve a
-    different purpose. It's quite possible, valid and even preferred in some occasions, to use [POST] to create resources,
-    or use [PUT] to update resources.</p>
+    different purpose. It's quite possible, valid and even preferred in some occasions, to use [PUT] to create resources,
+    or use [POST] to update resources.</p>
 
 <p>Use [PUT] when you can update a resource completely through a specific resource. For instance, if you know that an
     article resides at http://example.org/article/1234, you can [PUT] a new resource representation of this article


### PR DESCRIPTION
As per comment placed on previous commit:
>Since POST is usually used for creating a resource and PUT for updating, in the context of this paragraph they should be placed the other way around. The author is trying to say that both methods can sometimes be used in a mixed fashion.