### PR TITLE
Update 2013-04-20-loggingin.html

### DIFF
--- a/_posts/2013-04-20-loggingin.html
+++ b/_posts/2013-04-20-loggingin.html
@@ -54,7 +54,7 @@ Authentication: hmac johndoe:[digest]
 {% endhighlight %}
 
 <p>
-Right now, the server knows the user "johndoe" tries to acces the resource. The server can generate the digest as
+Right now, the server knows the user "johndoe" tries to access the resource. The server can generate the digest as
 well, since it has all information (note that the "password" is not encrypted on the server, as the server needs to know
 the actual value. Hence we call this a "secret", not a "password".
 </p>


### PR DESCRIPTION
Corrected spelling of "acces" to "access".