### PR TITLE
Correct capitalization of Content-Type header

### DIFF
--- a/_posts/2012-12-13-using-custom-content-types.html
+++ b/_posts/2012-12-13-using-custom-content-types.html
@@ -11,9 +11,9 @@ author_email: jthijssen@noxlogic.nl
 <p>Do not use a standard text/xml content-type. A client is not capable of handling this kind of information. Instead, use a custom format in the following form:</p>
 
 {% highlight xml %}
-Content-type: application/vnd+company.category+xml
-Content-type: application/vnd+company.category+html
-Content-type: application/vnd+company.category+json
+Content-Type: application/vnd+company.category+xml
+Content-Type: application/vnd+company.category+html
+Content-Type: application/vnd+company.category+json
 {% endhighlight %}
 
 <p>This allows your clients to process the information (in this case: your categories) as the specified content-type. All three of these content-types are categories,


### PR DESCRIPTION
The HTTP content-type header is capitalized 'Content-Type' , not 'Content-type'.